### PR TITLE
Allow serving precompressed content

### DIFF
--- a/server/src/static/staticRouter.js
+++ b/server/src/static/staticRouter.js
@@ -16,6 +16,7 @@ async function routes(fastify) {
   fastify.register(fastifyStatic, {
     root: frameworksDirectory,
     prefix: "/frameworks",
+    preCompressed: true,
     setHeaders: (res, path) => {
       if (isCSPEnabled && path.endsWith("index.html")) {
         res.setHeader(


### PR DESCRIPTION
These are really useful benchmarks. Thanks for creating and maintaining this repo!

I noticed that the Blazor WebAssembly "total bytes transferred" numbers are about 3x higher than what occurs in the real world, and tracked it down to the static server not enabling precompression. This also impacts lighthouse "consistently interactive" scores.

### What `preCompressed: true` does

If there's an incoming request for `somedir/somefile` and the request has `Accept-Encoding: br` (which browsers do send by default), and if on disk there's a file `somedir/somefile.br`, then the server will return that file with `Content-Encoding: br`. The equivalent is also true for `gz`. And if there is no precompressed version of the file on disk, it just serves `somedir/somefile` as usual, without any compression.

This is more representative of how things work in typical static file hosting scenarios, and aligns with some framework's build systems (for example Blazor, which does produce precompressed `.br` versions of files on build).